### PR TITLE
MVP 31 - Solo band editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## [0.1.5] - 2026-03-08
+
+### Added
+
+- **Solo while editing** (Token Visuals group in the Visualization Options bar):
+  - The new **Solo** toggle enables a temporary single-band preview mode: when selected, all other bands are temporarily removed from the DSP pipeline so you can hear the effect of one filter in isolation.
+  - Muting the active soloed band also ends the session cleanly before the mute is applied.
+  - When editing in solo mode all other bands become disabled (grayed out) and the soloed band is highlighted in the band grid.
+  - The Solo preference (on/off) is persisted in `localStorage` alongside other viz-options.
+
+### Fixed
+
+- **Band mute/unmute order stability for 3+ bands** (`filterEnablement.ts`):
+  - Muting a 3rd or subsequent band could record an incorrect original position in the overlay (compressed-list index compared to original-space overlay indices), causing the band-grid order to shift visibly.
+  - Re-enabling bands in any order other than mute order could insert them at wrong positions (ignored still-disabled gaps ahead of the restored filter), further reordering the band grid.
+  - Both `disableFilterEverywhere` and `enableFilterEverywhere` now reconstruct the full ordered name list before doing any index arithmetic, ensuring the pipeline order is always preserved regardless of how many bands are muted and in what order they are unmuted.
+  - 7 regression tests added covering 3-band and 5-band mute/unmute scenarios.
+
+### Changed
+
+- `vizOptionsPersistence.ts`: Added `soloWhileEditing` boolean to the persisted viz-options schema (default `false`).
+
+---
+
 ## [0.1.4] - 2026-02-22
 
 ### Added

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@camillaeq/client",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "description": "CamillaDSP equalizer UI",

--- a/client/src/lib/__tests__/filterEnablement.test.ts
+++ b/client/src/lib/__tests__/filterEnablement.test.ts
@@ -185,6 +185,133 @@ describe('filterEnablement', () => {
     });
   });
 
+  describe('multi-filter order stability (3+ bands) — regression', () => {
+    // These tests cover the bug where the 3rd+ mute recorded a wrong
+    // originalIndex (compressed-list index vs full-list index) and where
+    // re-enable inserted at the wrong position (ignoring still-disabled gaps).
+
+    const createFiveBandConfig = (): CamillaDSPConfig => ({
+      devices: {
+        samplerate: 48000,
+        chunksize: 1024,
+        capture: { type: 'Alsa', channels: 2, device: 'hw:1', format: 'S24LE3' },
+        playback: { type: 'Alsa', channels: 2, device: 'hw:0', format: 'S24LE3' },
+      },
+      filters: {
+        f1: { type: 'Biquad', parameters: { type: 'Peaking', freq: 100, q: 1, gain: 1 } },
+        f2: { type: 'Biquad', parameters: { type: 'Peaking', freq: 200, q: 1, gain: 2 } },
+        f3: { type: 'Biquad', parameters: { type: 'Peaking', freq: 500, q: 1, gain: 3 } },
+        f4: { type: 'Biquad', parameters: { type: 'Peaking', freq: 1000, q: 1, gain: 4 } },
+        f5: { type: 'Biquad', parameters: { type: 'Peaking', freq: 5000, q: 1, gain: 5 } },
+      },
+      mixers: {},
+      pipeline: [
+        { type: 'Filter', channels: [0], names: ['f1', 'f2', 'f3', 'f4', 'f5'] },
+      ],
+    });
+
+    it('records correct original indices for 3 consecutive mutes', () => {
+      const config = createMockConfig(); // [band1, band2, band3]
+      let updated = disableFilterEverywhere(config, 'band1'); // original index 0
+      updated = disableFilterEverywhere(updated, 'band2');    // original index 1
+      updated = disableFilterEverywhere(updated, 'band3');    // original index 2
+
+      const state = loadDisabledFilters();
+      expect(state.disabled.band1[0].index).toBe(0);
+      expect(state.disabled.band2[0].index).toBe(1);
+      expect(state.disabled.band3[0].index).toBe(2);
+    });
+
+    it('restores original order when enabling 3 bands in reverse mute order', () => {
+      const config = createMockConfig();
+      let updated = disableFilterEverywhere(config, 'band1');
+      updated = disableFilterEverywhere(updated, 'band2');
+      updated = disableFilterEverywhere(updated, 'band3');
+
+      // Enable in reverse order (worst case for the old bug)
+      updated = enableFilterEverywhere(updated, 'band3');
+      updated = enableFilterEverywhere(updated, 'band2');
+      updated = enableFilterEverywhere(updated, 'band1');
+
+      expect((updated.pipeline[0] as any).names).toEqual(['band1', 'band2', 'band3']);
+      expect((updated.pipeline[1] as any).names).toEqual(['band1', 'band2', 'band3']);
+    });
+
+    it('restores original order when enabling bands out of mute order', () => {
+      const config = createMockConfig();
+      let updated = disableFilterEverywhere(config, 'band1');
+      updated = disableFilterEverywhere(updated, 'band3');
+
+      // Enable in a different order
+      updated = enableFilterEverywhere(updated, 'band3');
+      updated = enableFilterEverywhere(updated, 'band1');
+
+      expect((updated.pipeline[0] as any).names).toEqual(['band1', 'band2', 'band3']);
+    });
+
+    it('enabling middle filter while outer filters stay disabled inserts at position 0', () => {
+      const config = createMockConfig();
+      let updated = disableFilterEverywhere(config, 'band1');
+      updated = disableFilterEverywhere(updated, 'band2');
+      updated = disableFilterEverywhere(updated, 'band3');
+
+      // Only re-enable band2 — band1 and band3 remain muted
+      updated = enableFilterEverywhere(updated, 'band2');
+
+      // band1 (index 0) and band3 (index 2) are still disabled;
+      // band2 (index 1) should be the only item in names[], at position 0
+      expect((updated.pipeline[0] as any).names).toEqual(['band2']);
+    });
+
+    it('5-band: mute 3 non-contiguous bands, unmute in random order, order preserved', () => {
+      const config = createFiveBandConfig(); // [f1, f2, f3, f4, f5]
+      let updated = disableFilterEverywhere(config, 'f1');
+      updated = disableFilterEverywhere(updated, 'f3');
+      updated = disableFilterEverywhere(updated, 'f5');
+
+      // Only f2 and f4 remain in pipeline
+      expect((updated.pipeline[0] as any).names).toEqual(['f2', 'f4']);
+
+      // Unmute in a random order
+      updated = enableFilterEverywhere(updated, 'f5');
+      updated = enableFilterEverywhere(updated, 'f1');
+      updated = enableFilterEverywhere(updated, 'f3');
+
+      expect((updated.pipeline[0] as any).names).toEqual(['f1', 'f2', 'f3', 'f4', 'f5']);
+    });
+
+    it('5-band: mute first 3 bands, unmute sequentially, order preserved', () => {
+      const config = createFiveBandConfig(); // [f1, f2, f3, f4, f5]
+      let updated = disableFilterEverywhere(config, 'f1');
+      updated = disableFilterEverywhere(updated, 'f2');
+      updated = disableFilterEverywhere(updated, 'f3');
+
+      // Only f4 and f5 remain
+      expect((updated.pipeline[0] as any).names).toEqual(['f4', 'f5']);
+
+      // Unmute in sequential order
+      updated = enableFilterEverywhere(updated, 'f1');
+      updated = enableFilterEverywhere(updated, 'f2');
+      updated = enableFilterEverywhere(updated, 'f3');
+
+      expect((updated.pipeline[0] as any).names).toEqual(['f1', 'f2', 'f3', 'f4', 'f5']);
+    });
+
+    it('5-band: mute first 3 bands, unmute in reverse, order preserved', () => {
+      const config = createFiveBandConfig(); // [f1, f2, f3, f4, f5]
+      let updated = disableFilterEverywhere(config, 'f1');
+      updated = disableFilterEverywhere(updated, 'f2');
+      updated = disableFilterEverywhere(updated, 'f3');
+
+      // Unmute in reverse
+      updated = enableFilterEverywhere(updated, 'f3');
+      updated = enableFilterEverywhere(updated, 'f2');
+      updated = enableFilterEverywhere(updated, 'f1');
+
+      expect((updated.pipeline[0] as any).names).toEqual(['f1', 'f2', 'f3', 'f4', 'f5']);
+    });
+  });
+
   describe('isFilterEnabledEverywhere', () => {
     it('returns true for enabled filters', () => {
       const config = createMockConfig();

--- a/client/src/lib/__tests__/vizOptionsPersistence.test.ts
+++ b/client/src/lib/__tests__/vizOptionsPersistence.test.ts
@@ -32,6 +32,7 @@ describe('vizOptionsPersistence', () => {
       heatmapMagnitudeGain: 2.5,
       heatmapGateThreshold: 0.05,
       heatmapMaxAlpha: 0.95,
+      soloWhileEditing: false,
     });
   });
 
@@ -53,6 +54,7 @@ describe('vizOptionsPersistence', () => {
       heatmapMagnitudeGain: 3.0,
       heatmapGateThreshold: 0.1,
       heatmapMaxAlpha: 0.8,
+      soloWhileEditing: true,
     };
 
     saveVizOptions(customState);
@@ -79,6 +81,7 @@ describe('vizOptionsPersistence', () => {
       heatmapMagnitudeGain: 2.5,
       heatmapGateThreshold: 0.05,
       heatmapMaxAlpha: 0.95,
+      soloWhileEditing: false,
     };
 
     saveVizOptions(invalidState);
@@ -105,6 +108,7 @@ describe('vizOptionsPersistence', () => {
       heatmapMagnitudeGain: 0.1, // Out of range [0.5..4.0]
       heatmapGateThreshold: 0.5, // Out of range [0.0..0.2]
       heatmapMaxAlpha: 1.5, // Out of range [0.2..1.0]
+      soloWhileEditing: false,
     };
 
     saveVizOptions(invalidState);
@@ -172,6 +176,7 @@ describe('vizOptionsPersistence', () => {
       heatmapMagnitudeGain: 3.0,
       heatmapGateThreshold: 0.1,
       heatmapMaxAlpha: 0.8,
+      soloWhileEditing: false,
     };
 
     saveVizOptions(customState);
@@ -284,6 +289,7 @@ describe('vizOptionsPersistence', () => {
       heatmapMagnitudeGain: 3.0,
       heatmapGateThreshold: 0.1,
       heatmapMaxAlpha: 0.8,
+      soloWhileEditing: true,
     };
 
     saveVizOptions(customState);

--- a/client/src/lib/filterEnablement.ts
+++ b/client/src/lib/filterEnablement.ts
@@ -39,17 +39,21 @@ export function disableFilterEverywhere(
       continue;
     }
     
-    // Calculate original position by accounting for already-disabled filters
     const stepKey = getStepKey(step.channels, stepIndex);
     const alreadyDisabled = getDisabledFiltersForStep(stepKey);
     
-    // Count how many disabled filters have indices before our current position
-    const disabledBefore = alreadyDisabled.filter((loc) => loc.index <= index).length;
+    // Reconstruct the full ordered name list (enabled names + disabled-at-original-positions)
+    // to find the correct original index of filterName in the pre-disable order.
+    // Comparing compressed-list indices to original-space overlay indices directly is wrong
+    // when 2+ filters are already disabled (causes drift from the 3rd mute onwards).
+    const fullNames: string[] = [...names];
+    for (const loc of alreadyDisabled) {
+      const insertIdx = Math.max(0, Math.min(fullNames.length, loc.index));
+      fullNames.splice(insertIdx, 0, loc.filterName);
+    }
+    const originalIndex = fullNames.indexOf(filterName);
     
-    // Original index = current index in compressed array + count of disabled filters that were before it
-    const originalIndex = index + disabledBefore;
-    
-    // Remove from names array
+    // Remove from enabled names array
     names.splice(index, 1);
     (updated.pipeline[stepIndex] as any).names = names;
     
@@ -97,9 +101,15 @@ export function enableFilterEverywhere(
         
         const names = (updated.pipeline[stepIndex] as any).names || [];
         
-        // Insert at original index (clamped to valid range)
-        const clampedIndex = Math.max(0, Math.min(names.length, location.index));
-        names.splice(clampedIndex, 0, filterName);
+        // Compute how many other disabled filters for this step had an original
+        // index less than location.index and are STILL disabled (i.e., still absent
+        // from names[]).  Those gaps must be subtracted to get the correct insertion
+        // point into the current compressed (enabled-only) names array.
+        const disabledBefore = getDisabledFiltersForStep(location.stepKey)
+          .filter(loc => loc.filterName !== filterName && loc.index < location.index)
+          .length;
+        const insertIndex = Math.max(0, Math.min(names.length, location.index - disabledBefore));
+        names.splice(insertIndex, 0, filterName);
         (updated.pipeline[stepIndex] as any).names = names;
         
         break;

--- a/client/src/lib/vizOptionsPersistence.ts
+++ b/client/src/lib/vizOptionsPersistence.ts
@@ -24,6 +24,7 @@ export interface VizOptionsState {
   showPerBandCurves: boolean;
   showBandwidthMarkers: boolean;
   bandFillOpacity: number;
+  soloWhileEditing: boolean;
   
   // Heatmap settings
   heatmapEnabled: boolean;
@@ -52,6 +53,7 @@ const DEFAULT_VIZ_OPTIONS: VizOptionsState = {
   showPerBandCurves: false,
   showBandwidthMarkers: true,
   bandFillOpacity: 0.4,
+  soloWhileEditing: false,
   
   // Heatmap defaults
   heatmapEnabled: false,
@@ -93,6 +95,7 @@ function validateVizOptions(state: Partial<VizOptionsState>): VizOptionsState {
   if (typeof state.showPeak === 'boolean') validated.showPeak = state.showPeak;
   if (typeof state.showPerBandCurves === 'boolean') validated.showPerBandCurves = state.showPerBandCurves;
   if (typeof state.showBandwidthMarkers === 'boolean') validated.showBandwidthMarkers = state.showBandwidthMarkers;
+  if (typeof state.soloWhileEditing === 'boolean') validated.soloWhileEditing = state.soloWhileEditing;
   if (typeof state.heatmapEnabled === 'boolean') validated.heatmapEnabled = state.heatmapEnabled;
   if (typeof state.heatmapHighPrecision === 'boolean') validated.heatmapHighPrecision = state.heatmapHighPrecision;
   

--- a/client/src/pages/eq/left/EqLeftPanel.svelte
+++ b/client/src/pages/eq/left/EqLeftPanel.svelte
@@ -18,6 +18,7 @@
     showPerBandCurves,
     showBandwidthMarkers,
     bandFillOpacity,
+    soloWhileEditing,
   } from '../vizOptions/vizOptionsStore';
 
   // Calculate octave and region column widths
@@ -103,6 +104,7 @@
         {showPerBandCurves}
         {showBandwidthMarkers}
         {bandFillOpacity}
+        {soloWhileEditing}
       />
       <div class="viz-options-spacer"></div>
     </div>

--- a/client/src/pages/eq/left/EqPlotArea.svelte
+++ b/client/src/pages/eq/left/EqPlotArea.svelte
@@ -11,7 +11,10 @@
     setBandGain,
     setBandQ,
     selectBand,
+    startSoloSession,
+    endSoloSession,
     preampGain,
+    soloActiveBandIndex,
   } from '../../../state/eqStore';
   import {
     spectrumMode,
@@ -30,6 +33,7 @@
     showBandwidthMarkers,
     bandFillOpacity,
     spectrumVizEnabled,
+    soloWhileEditing,
   } from '../vizOptions/vizOptionsStore';
   import {
     createSpectrumVizController,
@@ -136,6 +140,7 @@
       if (e.key === 'Shift') {
         shiftPressed = true;
       } else if (e.key === 'Escape' && $selectedBandIndex !== null) {
+        endSoloSession();
         selectBand(null);
       }
     };
@@ -231,6 +236,7 @@
   function handlePlotBackgroundClick(event: MouseEvent) {
     const target = event.target as Element;
     if (target.tagName === 'svg' || target.classList.contains('eq-plot')) {
+      endSoloSession();
       selectBand(null);
     }
   }
@@ -261,6 +267,7 @@
     };
     
     selectBand(bandIndex);
+    startSoloSession(bandIndex, $soloWhileEditing);
     setActiveEditing();
   }
   
@@ -490,7 +497,7 @@
               fill="none"
               stroke="var(--band-{(i % 10) + 1})"
               stroke-width="1.25"
-              opacity="0.4"
+              opacity={$soloActiveBandIndex !== null && $soloActiveBandIndex !== i ? 0.08 : 0.4}
               class="eq-curve-band"
             />
           {/each}
@@ -555,6 +562,7 @@
         bands={$bands}
         bandOrderNumbers={$bandOrderNumbers}
         selectedBandIndex={$selectedBandIndex}
+        soloActiveBandIndex={$soloActiveBandIndex}
         {plotWidth}
         {plotHeight}
         {shiftPressed}

--- a/client/src/pages/eq/right/EqBandColumn.svelte
+++ b/client/src/pages/eq/right/EqBandColumn.svelte
@@ -9,6 +9,8 @@
     setBandQ,
     toggleBandEnabled,
     selectBand,
+    startSoloSession,
+    soloActiveBandIndex,
   } from '../../../state/eqStore';
   import {
     showFaderTooltip,
@@ -16,6 +18,7 @@
     hideFaderTooltip,
     openFilterTypePicker,
   } from '../../../state/eqUiOverlayStore';
+  import { soloWhileEditing } from '../vizOptions/vizOptionsStore';
   
   export let band: EqBand;
   export let bandIndex: number;
@@ -111,13 +114,16 @@
   
   function handleSelect() {
     selectBand(bandIndex);
+    startSoloSession(bandIndex, $soloWhileEditing);
   }
   
   $: supportsGain = band.type === 'Peaking' || band.type === 'LowShelf' || band.type === 'HighShelf';
+  $: isSoloDimmed = $soloActiveBandIndex !== null && $soloActiveBandIndex !== bandIndex;
 </script>
 
 <div 
   class="band-column band" 
+  class:solo-dimmed={isSoloDimmed}
   style="--band-color: var(--band-{(bandIndex % 10) + 1});" 
   data-enabled={band.enabled}
   data-selected={selected}
@@ -384,5 +390,12 @@
   .knob-wrapper.disabled {
     pointer-events: none;
     opacity: 0.5;
+  }
+
+  /* Solo-edit session: dim non-active band columns */
+  .band-column.solo-dimmed {
+    opacity: 0.2;
+    pointer-events: none;
+    transition: opacity 0.15s ease;
   }
 </style>

--- a/client/src/pages/eq/vizOptions/VizOptionsBar.svelte
+++ b/client/src/pages/eq/vizOptions/VizOptionsBar.svelte
@@ -28,6 +28,7 @@ Uses VizLayoutManager for responsive layout with smart expansion/collapse behavi
   export let showPerBandCurves: Writable<boolean>;
   export let showBandwidthMarkers: Writable<boolean>;
   export let bandFillOpacity: Writable<number>;
+  export let soloWhileEditing: Writable<boolean>;
 
   const dispatch = createEventDispatcher<{
     resetAverages: void;
@@ -54,7 +55,7 @@ Uses VizLayoutManager for responsive layout with smart expansion/collapse behavi
           { id: 'g_curves', priority: 1, expandedWidth: 200, el: gCurvesEl },
           { id: 'g_smooth', priority: 2, expandedWidth: 190, el: gSmoothEl },
           { id: 'g_heatmap', priority: 3, expandedWidth: 210, el: gHeatmapEl },
-          { id: 'g_tokens', priority: 5, expandedWidth: 230, el: gTokensEl },
+          { id: 'g_tokens', priority: 5, expandedWidth: 270, el: gTokensEl },
         ];
         
         vizLayoutManager = new VizLayoutManager(
@@ -405,7 +406,8 @@ Uses VizLayoutManager for responsive layout with smart expansion/collapse behavi
       <div class="groupContainer expanded" id="g_tokens" data-group="tokens"
            data-curves={$showPerBandCurves ? 'on' : 'off'}
            data-bw={$showBandwidthMarkers ? 'on' : 'off'}
-           style="--expandedWidth:230px; --tokenFill:{$bandFillOpacity}">
+           data-solo={$soloWhileEditing ? 'on' : 'off'}
+           style="--expandedWidth:270px; --tokenFill:{$bandFillOpacity}">
 
         <div class="stubGlyph">
           <!--
@@ -436,7 +438,7 @@ Uses VizLayoutManager for responsive layout with smart expansion/collapse behavi
 
             <!-- solo-edit token dot (single-band-token): hidden until Solo mode is implemented -->
             <!-- Future hook: set data-solo="on" on #g_tokens to reveal via .tokGlyph-dot selector -->
-            <circle class="tokGlyph-dot" cx="7.93" cy="10.723" r="1.49"/>
+            <circle class="tokGlyph-dot" cx="7.93" cy="8" r="3"/>
           </svg>
         </div>
 
@@ -462,6 +464,15 @@ Uses VizLayoutManager for responsive layout with smart expansion/collapse behavi
               title="Show bandwidth (Q) markers"
             >
               BW
+            </button>
+            <button
+              class="chip option"
+              class:active={$soloWhileEditing}
+              aria-pressed={$soloWhileEditing}
+              on:click={() => ($soloWhileEditing = !$soloWhileEditing)}
+              title="Solo selected band while editing (mutes all others)"
+            >
+              Solo
             </button>
             <span class="knob-wrapper-inline" style="--knob-arc: var(--indigo);" title="Band fill opacity (Shift = fine adjust)" aria-label="Band fill opacity">
               <KnobDial 
@@ -1152,9 +1163,9 @@ Uses VizLayoutManager for responsive layout with smart expansion/collapse behavi
    * "edit one band, mute others" feature is implemented.
    */
   .tokGlyph-dot {
-    fill: var(--indigo);
-    stroke: #0e1116;
-    stroke-width: 0.6;
+    fill: #0e1116;
+    stroke: var(--teal);
+    stroke-width: 0.8;
     opacity: 0;
     transition: opacity 0.18s ease;
   }

--- a/client/src/pages/eq/vizOptions/vizOptionsStore.ts
+++ b/client/src/pages/eq/vizOptions/vizOptionsStore.ts
@@ -37,6 +37,7 @@ export const heatmapMaxAlpha = writable<number>(0.95);
 export const showPerBandCurves = writable<boolean>(false);
 export const showBandwidthMarkers = writable<boolean>(true);
 export const bandFillOpacity = writable<number>(0.4);
+export const soloWhileEditing = writable<boolean>(false);
 
 // Derived: spectrum visualization needed (analyzer OR heatmap)
 export const spectrumVizEnabled = derived(
@@ -58,6 +59,7 @@ export function initializeVizOptions(): void {
   showPerBandCurves.set(saved.showPerBandCurves);
   showBandwidthMarkers.set(saved.showBandwidthMarkers);
   bandFillOpacity.set(saved.bandFillOpacity);
+  soloWhileEditing.set(saved.soloWhileEditing);
   heatmapEnabled.set(saved.heatmapEnabled);
   heatmapMaskMode.set(saved.heatmapMaskMode);
   heatmapHighPrecision.set(saved.heatmapHighPrecision);
@@ -95,6 +97,7 @@ export function setupVizOptionsPersistence(): () => void {
       showPerBandCurves: null as any,
       showBandwidthMarkers: null as any,
       bandFillOpacity: null as any,
+      soloWhileEditing: null as any,
       heatmapEnabled: null as any,
       heatmapMaskMode: null as any,
       heatmapHighPrecision: null as any,
@@ -119,6 +122,7 @@ export function setupVizOptionsPersistence(): () => void {
     state.showPerBandCurves = readValue(showPerBandCurves);
     state.showBandwidthMarkers = readValue(showBandwidthMarkers);
     state.bandFillOpacity = readValue(bandFillOpacity);
+    state.soloWhileEditing = readValue(soloWhileEditing);
     state.heatmapEnabled = readValue(heatmapEnabled);
     state.heatmapMaskMode = readValue(heatmapMaskMode);
     state.heatmapHighPrecision = readValue(heatmapHighPrecision);
@@ -139,6 +143,7 @@ export function setupVizOptionsPersistence(): () => void {
   unsubscribers.push(showPerBandCurves.subscribe(saveAll));
   unsubscribers.push(showBandwidthMarkers.subscribe(saveAll));
   unsubscribers.push(bandFillOpacity.subscribe(saveAll));
+  unsubscribers.push(soloWhileEditing.subscribe(saveAll));
   unsubscribers.push(heatmapEnabled.subscribe(saveAll));
   unsubscribers.push(heatmapMaskMode.subscribe(saveAll));
   unsubscribers.push(heatmapHighPrecision.subscribe(saveAll));

--- a/client/src/state/__tests__/eqStore.soloSession.test.ts
+++ b/client/src/state/__tests__/eqStore.soloSession.test.ts
@@ -1,0 +1,341 @@
+/**
+ * MVP-31: eqStore solo-edit session tests
+ *
+ * These tests verify the startSoloEditSession / endSoloEditSession logic in
+ * isolation.  The DSP layer is mocked so no real WebSocket or HTTP calls are
+ * made.  The module-level mock for dspStore provides getDspInstance, and the
+ * test helper _injectDspForTesting is used for tests that need to reset the
+ * EQ state mid-suite.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+
+// ── Module mocks ─────────────────────────────────────────────────────────────
+
+// Shared mutable state for the fake DSP
+let mockDspConfig: any = null;
+const mockUploadConfig = vi.fn(async () => true);
+
+const mockDsp = {
+  get config() { return mockDspConfig; },
+  set config(v: any) { mockDspConfig = v; },
+  uploadConfig: mockUploadConfig,
+  downloadConfig: vi.fn(async () => true),
+};
+
+const mockPutLatestState = vi.fn(async (_cfg: any) => {});
+
+vi.mock('../dspStore', () => ({
+  getDspInstance: () => mockDsp,
+  updateConfig: vi.fn(),
+}));
+
+vi.mock('../../lib/api', () => ({
+  putLatestState: (cfg: any) => mockPutLatestState(cfg),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+import {
+  initializeFromConfig,
+  clearEqState,
+  startSoloEditSession,
+  endSoloEditSession,
+  isSoloSessionActive,
+  toggleBandEnabled,
+  _injectDspForTesting,
+  filterNames,
+  soloActiveBandIndex,
+  bands,
+  setBandGain,
+} from '../eqStore';
+
+/** Minimal 3-band CamillaDSP config with a named pipeline Filter step. */
+function makeConfig(overrides: Record<string, any> = {}) {
+  return {
+    filters: {
+      Filter01: { type: 'Biquad', parameters: { type: 'Peaking', freq: 100,  gain: 3,  q: 0.7 } },
+      Filter02: { type: 'Biquad', parameters: { type: 'Peaking', freq: 1000, gain: -3, q: 0.7 } },
+      Filter03: { type: 'Biquad', parameters: { type: 'Peaking', freq: 5000, gain: 1,  q: 0.7 } },
+    },
+    pipeline: [
+      { type: 'Filter', channel: 0, names: ['Filter01', 'Filter02', 'Filter03'] },
+    ],
+    mixers: {},
+    processors: {},
+    ...overrides,
+  };
+}
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
+
+describe('MVP-31: eqStore solo-edit session', () => {
+  beforeEach(() => {
+    mockDspConfig = makeConfig();
+    mockUploadConfig.mockReset();
+    mockUploadConfig.mockResolvedValue(true);
+    mockPutLatestState.mockReset();
+    initializeFromConfig(makeConfig() as any);
+  });
+
+  afterEach(() => {
+    clearEqState();
+  });
+
+  // ── State flags ────────────────────────────────────────────────────────────
+
+  it('returns false when no session is active', () => {
+    expect(isSoloSessionActive()).toBe(false);
+  });
+
+  it('returns true after startSoloEditSession', async () => {
+    await startSoloEditSession(0);
+    expect(isSoloSessionActive()).toBe(true);
+    await endSoloEditSession();
+  });
+
+  it('returns false after endSoloEditSession', async () => {
+    await startSoloEditSession(0);
+    await endSoloEditSession();
+    expect(isSoloSessionActive()).toBe(false);
+  });
+
+  // ── Config mutations on START ──────────────────────────────────────────────
+
+  it('writes a config with only the active filter to the DSP on session start', async () => {
+    let capturedConfig: any = null;
+    mockUploadConfig.mockImplementation(async () => {
+      capturedConfig = JSON.parse(JSON.stringify(mockDspConfig));
+      return true;
+    });
+
+    await startSoloEditSession(0);
+
+    expect(capturedConfig).not.toBeNull();
+    const names: string[] = capturedConfig.pipeline[0].names;
+    expect(names).toContain('Filter01');
+    expect(names).not.toContain('Filter02');
+    expect(names).not.toContain('Filter03');
+
+    await endSoloEditSession();
+  });
+
+  it('calls uploadConfig once on session start', async () => {
+    await startSoloEditSession(0);
+    expect(mockUploadConfig).toHaveBeenCalledTimes(1);
+    await endSoloEditSession();
+  });
+
+  it('keeps non-EQ pipeline steps unchanged during solo', async () => {
+    // Config with a Mixer before the Filter step
+    const mixedConfig = makeConfig({
+      pipeline: [
+        { type: 'Mixer', name: 'myMixer' },
+        { type: 'Filter', channel: 0, names: ['Filter01', 'Filter02', 'Filter03'] },
+      ],
+      mixers: { myMixer: {} },
+    });
+    mockDspConfig = mixedConfig;
+    initializeFromConfig(mixedConfig as any);
+
+    let capturedConfig: any = null;
+    mockUploadConfig.mockImplementation(async () => {
+      capturedConfig = JSON.parse(JSON.stringify(mockDspConfig));
+      return true;
+    });
+
+    // band index 0 corresponds to Filter01, which is at pipeline position 1 (after Mixer)
+    await startSoloEditSession(0);
+
+    expect(capturedConfig.pipeline[0].type).toBe('Mixer');
+    expect(capturedConfig.pipeline[0].name).toBe('myMixer');
+
+    await endSoloEditSession();
+  });
+
+  it('soloActiveBandIndex store is set to the active band during session', async () => {
+    // UI components subscribe to this to dim non-active bands/tokens/curves
+    await startSoloEditSession(0);
+    expect(get(soloActiveBandIndex)).toBe(0);
+    await endSoloEditSession();
+  });
+
+  it('soloActiveBandIndex store is null after session ends', async () => {
+    await startSoloEditSession(0);
+    await endSoloEditSession();
+    expect(get(soloActiveBandIndex)).toBeNull();
+  });
+
+  // ── filterNames store ─────────────────────────────────────────────────────
+
+  it('filterNames store still has all 3 bands during solo (UI position/colour stable)', async () => {
+    // The solo session patches the DSP pipeline but keeps the full band list
+    // in UI stores so band columns, tokens and curves do not shift/recolour.
+    await startSoloEditSession(0);
+    expect(get(filterNames)).toHaveLength(3);
+    expect(get(filterNames)[0]).toBe('Filter01');
+    await endSoloEditSession();
+  });
+
+  // ── Config mutations on END ────────────────────────────────────────────────
+
+  it('restores all 3 filters to the pipeline on session end', async () => {
+    await startSoloEditSession(0);
+    await endSoloEditSession();
+
+    const names: string[] = mockDspConfig.pipeline[0].names;
+    expect(names).toHaveLength(3);
+    expect(names).toContain('Filter01');
+    expect(names).toContain('Filter02');
+    expect(names).toContain('Filter03');
+  });
+
+  it('filterNames store has all 3 filters after session end', async () => {
+    await startSoloEditSession(0);
+    await endSoloEditSession();
+    expect(get(filterNames)).toHaveLength(3);
+  });
+
+  it('preserves parameter edits to the active band in the restored config', async () => {
+    await startSoloEditSession(0);
+    // Edit band 0 gain during the session
+    setBandGain(0, 9);
+    // Allow the debounce to fire (or flush it)
+    await new Promise(r => setTimeout(r, 250));
+    await endSoloEditSession();
+
+    expect(mockDspConfig.filters['Filter01'].parameters.gain).toBe(9);
+    expect(mockDspConfig.filters['Filter02'].parameters.gain).toBe(-3);
+  });
+
+  it('does not change non-active band parameters on restore', async () => {
+    await startSoloEditSession(1); // solo Filter02
+    await endSoloEditSession();
+
+    expect(mockDspConfig.filters['Filter01'].parameters.freq).toBe(100);
+    expect(mockDspConfig.filters['Filter03'].parameters.freq).toBe(5000);
+  });
+
+  // ── Upload / persist counts ────────────────────────────────────────────────
+
+  it('calls uploadConfig exactly once on session end', async () => {
+    await startSoloEditSession(0);
+    mockUploadConfig.mockReset();
+    mockUploadConfig.mockResolvedValue(true);
+    await endSoloEditSession();
+    expect(mockUploadConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT call fetch (putLatestState) at session start', async () => {
+    await startSoloEditSession(0);
+    expect(mockPutLatestState).not.toHaveBeenCalled();
+    await endSoloEditSession();
+  });
+
+  it('calls fetch (putLatestState) after session end', async () => {
+    await startSoloEditSession(0);
+    mockPutLatestState.mockReset();
+    await endSoloEditSession();
+    expect(mockPutLatestState).toHaveBeenCalledOnce();
+  });
+
+  // ── Guard conditions ───────────────────────────────────────────────────────
+
+  it('does nothing on a second startSoloEditSession call while already in session', async () => {
+    await startSoloEditSession(0);
+    const uploadCountAfterFirst = mockUploadConfig.mock.calls.length;
+    // Session is already active — second call should be a no-op (same band)
+    // Implementation ends old session and starts new one; state must remain active
+    expect(isSoloSessionActive()).toBe(true);
+  });
+
+  it('endSoloEditSession is a no-op when no session is active', async () => {
+    await endSoloEditSession(); // should not throw
+    expect(isSoloSessionActive()).toBe(false);
+    expect(mockUploadConfig).not.toHaveBeenCalled();
+  });
+
+  it('does not start a session if uploadConfig returns false', async () => {
+    mockUploadConfig.mockResolvedValueOnce(false);
+    await startSoloEditSession(0);
+    expect(isSoloSessionActive()).toBe(false);
+  });
+
+  it('does not start a session if no config has been initialized', async () => {
+    // _injectDspForTesting resets all EQ state (lastConfig → null) while
+    // providing a new mock DSP so we can test the "no config" guard path.
+    _injectDspForTesting(mockDsp);
+    await startSoloEditSession(0);
+    expect(isSoloSessionActive()).toBe(false);
+    // Restore for afterEach
+    initializeFromConfig(makeConfig() as any);
+  });
+
+  it('immediately restores all filters when endSoloEditSession called with no edits', async () => {
+    let restoredConfig: any = null;
+    mockUploadConfig.mockImplementation(async () => {
+      restoredConfig = JSON.parse(JSON.stringify(mockDspConfig));
+      return true;
+    });
+
+    await startSoloEditSession(0);
+    restoredConfig = null; // reset — only care about end upload
+    await endSoloEditSession();
+
+    expect(restoredConfig).not.toBeNull();
+    const names: string[] = restoredConfig.pipeline[0].names;
+    expect(names).toContain('Filter01');
+    expect(names).toContain('Filter02');
+    expect(names).toContain('Filter03');
+  });
+
+  // ── Mute interaction during solo ──────────────────────────────────────────
+
+  it('muting the active solo band ends the solo session', async () => {
+    await startSoloEditSession(0);
+    expect(isSoloSessionActive()).toBe(true);
+
+    await toggleBandEnabled(0); // mute the active (soloed) band
+
+    expect(isSoloSessionActive()).toBe(false);
+  });
+
+  it('soloActiveBandIndex is null after muting the active solo band', async () => {
+    await startSoloEditSession(0);
+    await toggleBandEnabled(0);
+
+    expect(get(soloActiveBandIndex)).toBeNull();
+  });
+
+  it('the active band is disabled in the UI after muting it during solo', async () => {
+    await startSoloEditSession(0);
+    await toggleBandEnabled(0); // mute band 0 (was soloed)
+
+    // Allow debounce to settle
+    await new Promise(r => setTimeout(r, 250));
+
+    const currentBands = get(bands);
+    expect(currentBands[0].enabled).toBe(false);
+    // Other bands stay enabled
+    expect(currentBands[1].enabled).toBe(true);
+    expect(currentBands[2].enabled).toBe(true);
+  });
+
+  it('all 3 filters are restored to the pipeline before the mute is applied', async () => {
+    const uploadSequence: string[][] = [];
+    mockUploadConfig.mockImplementation(async () => {
+      const step = (mockDspConfig.pipeline[0] as any);
+      uploadSequence.push([...step.names]);
+      return true;
+    });
+
+    await startSoloEditSession(0); // upload 1: solo patch (only Filter01)
+    await toggleBandEnabled(0);    // upload 2: restore (all 3), upload 3: mute (via debounce)
+    await new Promise(r => setTimeout(r, 250)); // let debounce fire
+
+    // Second upload must be the full restore, not just the solo patch
+    expect(uploadSequence[1]).toContain('Filter02');
+    expect(uploadSequence[1]).toContain('Filter03');
+  });
+});

--- a/client/src/state/eqStore.ts
+++ b/client/src/state/eqStore.ts
@@ -78,23 +78,33 @@ const debouncedUpload = debounceCancelable(async () => {
       lastConfig = confirmedConfig;
       updateDspConfig(confirmedConfig); // Sync global dspStore
       
-      // Re-extract EQ bands from confirmed config to ensure UI reflects what DSP accepted
-      const reExtracted = extractEqBandsFromConfig(confirmedConfig);
-      extractedData = reExtracted;
-      bands.set(reExtracted.bands);
-      filterNames.set(reExtracted.filterNames);
-      bandOrderNumbers.set(reExtracted.orderNumbers);
-      preampGain.set(reExtracted.preampGain);
-      
-      // Persist confirmed config to server as latest state (write-through)
-      try {
-        await putLatestState(confirmedConfig);
-      } catch (error) {
-        console.warn('Failed to persist latest state to server:', error);
-        // Non-fatal: continue even if persistence fails
+      if (soloSessionActive) {
+        // During a solo session the pipeline is temporarily patched (only the
+        // active band is in names[]).  Re-extracting would collapse filterNames
+        // to a single entry, shifting band positions, changing colours etc.
+        // Instead we leave filterNames/bands/bandOrderNumbers unchanged and
+        // only update lastConfig so parameter edits are captured correctly.
+        uploadStatus.set({ state: 'success' });
+      } else {
+        // Re-extract EQ bands from confirmed config to ensure UI reflects
+        // what DSP accepted.
+        const reExtracted = extractEqBandsFromConfig(confirmedConfig);
+        extractedData = reExtracted;
+        bands.set(reExtracted.bands);
+        filterNames.set(reExtracted.filterNames);
+        bandOrderNumbers.set(reExtracted.orderNumbers);
+        preampGain.set(reExtracted.preampGain);
+        
+        // Persist confirmed config to server as latest state (write-through)
+        try {
+          await putLatestState(confirmedConfig);
+        } catch (error) {
+          console.warn('Failed to persist latest state to server:', error);
+          // Non-fatal: continue even if persistence fails
+        }
+        
+        uploadStatus.set({ state: 'success' });
       }
-      
-      uploadStatus.set({ state: 'success' });
       
       // Clear success state after 2 seconds
       setTimeout(() => {
@@ -175,8 +185,14 @@ export function clearEqState(): void {
   extractedData = null;
   bands.set([]);
   filterNames.set([]);
+  bandOrderNumbers.set([]);
   preampGain.set(0);
   uploadStatus.set({ state: 'idle' });
+  // Reset solo session (don't restore — config is gone)
+  soloSessionActive = false;
+  soloSnapshot = null;
+  soloActiveBandIndex.set(null);
+  _testDspOverride = null;
 }
 
 /**
@@ -234,7 +250,7 @@ export function setBandType(index: number, type: EqBand['type']) {
   debouncedUpload.call();
 }
 
-export function toggleBandEnabled(index: number) {
+export async function toggleBandEnabled(index: number): Promise<void> {
   const dspInstance = getDspInstance();
   if (!dspInstance || !lastConfig || !extractedData) {
     console.error('Cannot toggle band: no DSP instance or config');
@@ -251,6 +267,14 @@ export function toggleBandEnabled(index: number) {
   // Get current enabled state
   const currentBands = get(bands);
   const isCurrentlyEnabled = currentBands[index]?.enabled ?? false;
+
+  // Solo-mute interaction: muting the active soloed band ends the solo session
+  // first, so the full pipeline is restored before the persistent mute is applied.
+  // (Non-active bands are already non-interactive via solo-dimmed pointer-events:none.)
+  if (soloSessionActive && isCurrentlyEnabled && index === get(soloActiveBandIndex)) {
+    await endSoloEditSession();
+    // lastConfig and extractedData are now the restored (pre-solo) state.
+  }
 
   try {
     // Toggle by disabling/enabling everywhere in pipeline
@@ -284,6 +308,179 @@ export function toggleBandEnabled(index: number) {
       message: error instanceof Error ? error.message : 'Failed to toggle band',
     });
   }
+}
+
+// ─── MVP-31: Solo session state ────────────────────────────────────────────
+
+let soloSessionActive = false;
+/** Snapshot of pipeline names[] per Filter step, captured at session start. */
+let soloSnapshot: { stepIndex: number; names: string[] }[] | null = null;
+
+/**
+ * The band index that is currently being soloed, or null when no session is
+ * active.  UI components subscribe to this to dim non-active bands/tokens/curves.
+ */
+export const soloActiveBandIndex = writable<number | null>(null);
+
+// Test-only DSP override (null in production)
+let _testDspOverride: any = null;
+
+/** Returns the DSP instance, honouring any test override. */
+function _resolveDspInstance() {
+  return (_testDspOverride ?? getDspInstance()) as { config: any; uploadConfig: () => Promise<boolean> } | null;
+}
+
+/**
+ * Test helper: inject a mock DSP instance and reset EQ state so tests
+ * start with a clean slate (no stale lastConfig from a previous test).
+ * Must only be called from test code.
+ */
+export function _injectDspForTesting(dsp: any): void {
+  debouncedUpload.cancel();
+  lastConfig = null;
+  extractedData = null;
+  bands.set([]);
+  filterNames.set([]);
+  bandOrderNumbers.set([]);
+  preampGain.set(0);
+  uploadStatus.set({ state: 'idle' });
+  soloSessionActive = false;
+  soloSnapshot = null;
+  soloActiveBandIndex.set(null);
+  _testDspOverride = dsp;
+}
+
+/** Returns whether a solo-edit session is currently active. */
+export function isSoloSessionActive(): boolean {
+  return soloSessionActive;
+}
+
+/**
+ * Start a solo-edit session: mute every band except `bandIndex`, upload the
+ * temporary config directly (no debounce, no putLatestState), and set the
+ * session-active flag.  A no-op when:
+ *  - no config has been loaded (`lastConfig` / `extractedData` are null), or
+ *  - no DSP instance is available, or
+ *  - the upload to CamillaDSP fails.
+ *
+ * If a session is already active the existing one is ended first (band switch).
+ */
+export async function startSoloEditSession(bandIndex: number): Promise<void> {
+  if (!lastConfig || !extractedData) return;
+  const dspInstance = _resolveDspInstance();
+  if (!dspInstance) return;
+
+  // Band-switch: end the current session silently before starting a new one
+  if (soloSessionActive) {
+    await endSoloEditSession();
+  }
+
+  const activeName = extractedData.filterNames[bandIndex];
+  if (!activeName) return; // invalid band index
+
+  // Deep-clone the config so we can patch pipeline names[] directly.
+  // This avoids writing to the disabled-filters localStorage overlay, which would
+  // cause extractEqBandsFromConfig to include the muted bands in the band list.
+  const updatedConfig = JSON.parse(JSON.stringify(lastConfig)) as CamillaDSPConfig;
+  const pipeline = (updatedConfig.pipeline as any[] | undefined) ?? [];
+
+  // Snapshot of each Filter step's original names[] so we can restore later
+  const snapshot: { stepIndex: number; names: string[] }[] = [];
+  let changed = false;
+
+  for (let i = 0; i < pipeline.length; i++) {
+    const step = pipeline[i];
+    if (step.type !== 'Filter' || !Array.isArray(step.names)) continue;
+
+    snapshot.push({ stepIndex: i, names: [...step.names] });
+
+    // Keep only the active filter in this step's names[]
+    const newNames: string[] = step.names.includes(activeName) ? [activeName] : [];
+    if (newNames.length !== step.names.length) {
+      step.names = newNames;
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    dspInstance.config = updatedConfig;
+    const success = await dspInstance.uploadConfig();
+    if (!success) return; // upload failed — do not activate session
+
+    // Update lastConfig only — do NOT re-extract.
+    // All bands remain in filterNames/bands/bandOrderNumbers so the UI stays
+    // stable (positions, order numbers, colours unchanged).  The debouncedUpload
+    // guard (soloSessionActive) will also skip re-extraction on subsequent edits.
+    lastConfig = updatedConfig;
+  }
+
+  soloSnapshot = snapshot;
+  soloSessionActive = true;
+  soloActiveBandIndex.set(bandIndex); // signals UI to dim non-active bands
+}
+
+/**
+ * End the current solo-edit session: restore all bands to their pre-session
+ * enabled state, upload the restored config directly, and persist to the
+ * server via putLatestState (recovery cache).  A no-op when no session is
+ * active.
+ */
+export async function endSoloEditSession(): Promise<void> {
+  if (!soloSessionActive) return;
+  soloSessionActive = false;
+  soloActiveBandIndex.set(null); // clear UI dimming immediately
+
+  if (!soloSnapshot || !lastConfig) {
+    soloSnapshot = null;
+    return;
+  }
+
+  const dspInstance = _resolveDspInstance();
+  if (!dspInstance) {
+    soloSnapshot = null;
+    return;
+  }
+
+  // Restore pipeline names[] from snapshot
+  const updatedConfig = JSON.parse(JSON.stringify(lastConfig)) as CamillaDSPConfig;
+  const pipeline = (updatedConfig.pipeline as any[] | undefined) ?? [];
+
+  for (const snap of soloSnapshot) {
+    if (pipeline[snap.stepIndex]) {
+      pipeline[snap.stepIndex].names = snap.names;
+    }
+  }
+
+  soloSnapshot = null;
+
+  dspInstance.config = updatedConfig;
+  await dspInstance.uploadConfig();
+  lastConfig = updatedConfig;
+  const extracted = extractEqBandsFromConfig(updatedConfig);
+  extractedData = extracted;
+  bands.set(extracted.bands);
+  filterNames.set(extracted.filterNames);
+  bandOrderNumbers.set(extracted.orderNumbers);
+
+  // Persist the restored (real) config to the server as a recovery point
+  try {
+    await putLatestState(lastConfig);
+  } catch {
+    // Non-fatal
+  }
+}
+
+/**
+ * UI convenience wrappers — check the soloWhileEditing toggle before
+ * calling the underlying session functions.
+ */
+export function startSoloSession(bandIndex: number, soloEnabled: boolean): void {
+  if (!soloEnabled) return;
+  void startSoloEditSession(bandIndex);
+}
+
+export function endSoloSession(): void {
+  void endSoloEditSession();
 }
 
 export function selectBand(index: number | null) {

--- a/client/src/ui/tokens/EqTokensLayer.svelte
+++ b/client/src/ui/tokens/EqTokensLayer.svelte
@@ -18,6 +18,7 @@
   export let plotHeight: number;
   export let shiftPressed: boolean;
   export let focusMode: boolean = false; // MVP-14: dim unselected tokens in focus mode
+  export let soloActiveBandIndex: number | null = null; // MVP-31: dim non-active tokens during solo
 
   const dispatch = createEventDispatcher<{
     tokenPointerDown: { bandIndex: number; event: PointerEvent };
@@ -89,7 +90,7 @@
     
     // MVP-14: Focus mode dimming
     {@const isSelected = selectedBandIndex === i}
-    {@const shouldDim = (focusMode && !isSelected) || !band.enabled}
+    {@const shouldDim = (focusMode && !isSelected) || !band.enabled || (soloActiveBandIndex !== null && soloActiveBandIndex !== i)}
     {@const showLabels = !focusMode || isSelected}
     
     <g 

--- a/client/src/ui/tokens/EqTokensLayer.svelte
+++ b/client/src/ui/tokens/EqTokensLayer.svelte
@@ -89,7 +89,7 @@
     
     // MVP-14: Focus mode dimming
     {@const isSelected = selectedBandIndex === i}
-    {@const shouldDim = focusMode && !isSelected}
+    {@const shouldDim = (focusMode && !isSelected) || !band.enabled}
     {@const showLabels = !focusMode || isSelected}
     
     <g 

--- a/docs/developer/frontend.md
+++ b/docs/developer/frontend.md
@@ -145,6 +145,9 @@ Notes:
   - `setBandFreq()` / `setBandGain()` / `setBandQ()` - Optimistic updates (with clamping)
   - Debounced upload with convergence happens internally (upload → re-download → sync)
   - `selectBand()` - Track selected band index (UI focus mode)
+  - `startSoloEditSession(bandIndex)` - Begin solo preview: uploads a reduced config (active band only), sets `soloActiveBandIndex`
+  - `endSoloEditSession()` - Restore full config, clear `soloActiveBandIndex`, persist recovery cache
+- **Exported readable:** `soloActiveBandIndex` (`number | null`) — consumed by `EqTokensLayer` to apply dimming to non-active tokens during a solo session
 
 **pipelineEditor.ts**
 - **Type:** Helper functions + callback

--- a/docs/developer/state-and-persistence.md
+++ b/docs/developer/state-and-persistence.md
@@ -63,6 +63,7 @@ All UI state must eventually converge to what CamillaDSP confirms.
 - EQ bands array (frequency, gain, Q, type, enabled)
 - Focused band (UI-only)
 - Dragging state (UI-only)
+- `soloActiveBandIndex` — readable store (`number | null`); non-null while a solo-edit session is active; consumed by `EqTokensLayer` to dim non-active tokens
 
 **Lifecycle:** Re-initialized on:
 - Connection established
@@ -75,6 +76,12 @@ All UI state must eventually converge to what CamillaDSP confirms.
 - Extracts bands from DSP config via `extractEqBandsFromConfig()`
 - After upload, re-downloads DSP config and re-extracts
 - Preserves UI-only state (focused, dragging) across re-initialization
+
+**Solo-edit session:**
+- `startSoloEditSession(bandIndex)` — builds a reduced DSP config containing only the active band's filter and uploads it; sets `soloActiveBandIndex`; no-ops if already in session or upload fails
+- `endSoloEditSession()` — restores the full config (with any parameter edits applied during solo), uploads it, clears `soloActiveBandIndex`, and writes the recovery cache; no-ops if no session is active
+- Muting the active band calls `endSoloEditSession()` first (restores all filters), then applies the persistent mute
+- Session does **not** modify `filterNames` or band order — the UI grid remains stable throughout
 
 ---
 
@@ -112,12 +119,13 @@ All UI state must eventually converge to what CamillaDSP confirms.
 
 **Storage key:** `camillaEQ.vizOptions`
 
-**State persisted (15 settings):**
+**State persisted (16 settings):**
 - Spectrum mode (pre/post)
 - Smoothing mode (off, 1/12, 1/6, 1/3)
 - Analyzer series (showSTA, showLTA, showPeak)
 - EQ view options (showPerBandCurves, showBandwidthMarkers, bandFillOpacity)
 - Heatmap (enabled, maskMode, highPrecision, visual tuning parameters)
+- `soloWhileEditing` (boolean, default `false`) — whether the Solo toggle is active
 
 **Lifecycle:**
 - Loaded on EqPage mount
@@ -303,6 +311,16 @@ But we need to remember **where** it was, so re-enabling puts it back in the rig
 - Updated when pipeline reordered (remap step keys)
 - Cleared when filter deleted
 - Cleared when step deleted
+
+**Stable-order invariant (`filterEnablement.ts`):**
+
+Both `disableFilterEverywhere` and `enableFilterEverywhere` reconstruct the **full ordered filter name list** (active + disabled, in original position order) before computing any index arithmetic.
+
+This is necessary because:
+- The pipeline step only contains *active* filters; indices inside that list are compressed (e.g. position 2 of 5, with gaps for disabled filters, is position 1 in the pipeline array).
+- Storing or restoring using the compressed-list index causes silent off-by-one errors when ≥2 filters are already disabled.
+
+By rebuilding the full list first, the index recorded in the overlay and the insertion point used on restore both refer to the same original position space, so band-grid order is preserved regardless of how many bands are muted and in what order they are unmuted.
 
 ---
 

--- a/docs/end-user/quick-start.md
+++ b/docs/end-user/quick-start.md
@@ -148,6 +148,12 @@ A fresh CamillaDSP install often starts with an empty or minimal config.
 - **Power button (⏻):** Disable/enable band
 - **Filter icon:** Change filter type (Peaking, Shelf, Pass, etc.)
 
+**Visualization Options:**
+- **Spectrum Curves:** Long term average (LTA) and short term average (STA) spectrum curves as well as Peak.
+- **Curve Smoothing:** Smoothing options for the LTA and STA curves.
+- **Heatmap:** Shows the frequency response of the EQ in a heatmap. 
+- The **Solo** toggle (in the **Token Visuals** group) lets you hear a single band in isolation temporarily while editing it.
+
 ### 3. Changes Upload Automatically
 
 CamillaEQ uploads your changes to CamillaDSP after a 200ms pause in editing (debounced).

--- a/docs/end-user/troubleshooting.md
+++ b/docs/end-user/troubleshooting.md
@@ -328,6 +328,28 @@
 
 ---
 
+### Solo Session Not Ending
+
+**Symptoms:**
+- All non-active band tokens remain dimmed after you expect the EQ to have been restored
+- Spectrum or perceived audio sounds like only one band is active
+
+**What this means:**
+- A "solo while editing" session is still active
+- The session ends when you deselect the active band, mute it, or turn off the **Solo** toggle
+
+**Solutions:**
+
+1. **Click away from the active token** (click an empty area of the EQ plot) to deselect it — the session ends immediately.
+2. **Turn off the Solo toggle** in Visualization Options → Token Visuals.
+3. **Mute the active band** (power button ⏻ on the selected band column) — this also ends the solo session and then persistently mutes that band.
+
+If the UI still shows all bands dimmed after the above:
+- Reload the page (hard reload: Cmd+Shift+R / Ctrl+Shift+R)
+- Reconnecting re-downloads the current CamillaDSP config, which restores all bands
+
+---
+
 ### Disabled Filters Not Restoring
 
 **Symptoms:**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camillaeq",
-  "version": "0.1.0",
+  "version": "0.1.5",
   "private": true,
   "description": "CamillaDSP graphical equalizer interface",
   "workspaces": [

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@camillaeq/server",
-  "version": "0.1.0",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "description": "CamillaDSP REST API server",

--- a/server/src/routes/version.ts
+++ b/server/src/routes/version.ts
@@ -3,7 +3,7 @@ import { FastifyInstance } from 'fastify';
 export function registerVersionRoutes(app: FastifyInstance): void {
   app.get('/api/version', async () => {
     return {
-      version: '0.1.4',
+      version: '0.1.5',
       buildHash: process.env.BUILD_HASH || 'dev',
       buildTime: process.env.BUILD_TIME || new Date().toISOString(),
     };


### PR DESCRIPTION
### Added

- **Solo band editing**
  - The new **Solo** toggle in the Token Visuals group in the Visualization Options bar enables a temporary single-band preview mode: when selected, all other bands are temporarily removed from the DSP pipeline so you can hear the effect of one filter in isolation.
  - Muting the active soloed band also ends the session cleanly before the mute is applied.
  - When editing in solo mode all other bands become disabled (grayed out) and the soloed band is highlighted in the band grid.
  - The Solo preference (on/off) is persisted in `localStorage` alongside other viz-options.

### Fixed

- **Band mute/unmute order stability for 3+ bands** (`filterEnablement.ts`):
  - Muting a 3rd or subsequent band could record an incorrect original position in the overlay (compressed-list index compared to original-space overlay indices), causing the band-grid order to shift visibly.
  - Re-enabling bands in any order other than mute order could insert them at wrong positions (ignored still-disabled gaps ahead of the restored filter), further reordering the band grid.
  - Both `disableFilterEverywhere` and `enableFilterEverywhere` now reconstruct the full ordered name list before doing any index arithmetic, ensuring the pipeline order is always preserved regardless of how many bands are muted and in what order they are unmuted.
  - 7 regression tests added covering 3-band and 5-band mute/unmute scenarios.

### Changed

- `vizOptionsPersistence.ts`: Added `soloWhileEditing` boolean to the persisted viz-options schema (default `false`).